### PR TITLE
Try to keep user configuration on update

### DIFF
--- a/fail2ban/conf/jail.d/dovecot.conf
+++ b/fail2ban/conf/jail.d/dovecot.conf
@@ -1,0 +1,2 @@
+[dovecot]
+enabled = true

--- a/fail2ban/conf/jail.d/postfix-sasl.conf
+++ b/fail2ban/conf/jail.d/postfix-sasl.conf
@@ -1,0 +1,2 @@
+[postfix-sasl]
+enabled = true

--- a/fail2ban/conf/jail.d/postfix.conf
+++ b/fail2ban/conf/jail.d/postfix.conf
@@ -1,0 +1,2 @@
+[postfix]
+enabled = true

--- a/fail2ban/conf/jail.d/sieve.conf
+++ b/fail2ban/conf/jail.d/sieve.conf
@@ -1,0 +1,2 @@
+[sieve]
+enabled = true

--- a/fail2ban/conf/jail.d/sshd.conf
+++ b/fail2ban/conf/jail.d/sshd.conf
@@ -1,0 +1,2 @@
+[sshd]
+enabled = true

--- a/fail2ban/conf/jail.local
+++ b/fail2ban/conf/jail.local
@@ -1,18 +1,2 @@
 [DEFAULT]
 bantime = 3600
-
-[sshd]
-enabled = true
-
-[postfix-sasl]
-enabled = true
-
-[postfix]
-enabled = true
-
-[sieve]
-enabled = true
-
-[dovecot]
-enabled = true
-

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -612,9 +612,12 @@ A backup will be stored in ./before_upgrade_$timestamp
 	returnwait "Webserver configuration" "Roundcube configuration"
 
 	installtask roundcube
-	sed -i "s/conf_rcdeskey/$old_des_key_rc/g" /var/www/mail/rc/config/config.inc.php
-	chmod +x /var/www/mail/rc/bin/updatedb.sh
-	/var/www/mail/rc/bin/updatedb.sh --package=roundcube --dir=/var/www/mail/rc/SQL
+	# y not use the update tool of roundcube?
+	# saves user configuration and plugins/skins
+	# TODO: err, if already up2date
+	tar xf roundcube/inst/$roundcube_version.tar -C roundcube/inst/
+	chmod +x roundcube/inst/$roundcube_version/bin/installto.sh
+	roundcube/inst/$roundcube_version/bin/installto.sh /var/www/mail/rc
 	returnwait "Roundcube configuration" "OpenDKIM configuration"
 
 	installtask opendkim

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -477,7 +477,10 @@ DatabaseMirror db.local.clamav.net" >> /etc/clamav/freshclam.conf
 			if [[ ! -f /var/log/mail.warn ]]; then
 				touch /var/log/mail.warn
 			fi
-			cp fail2ban/conf/jail.local /etc/fail2ban/jail.local
+			if [[ ! -f /etc/fail2ban/jail.local ]]; then
+				cp fail2ban/conf/jail.local /etc/fail2ban/jail.local
+			fi
+			cp fail2ban/conf/jail.d/*.conf /etc/fail2ban/jail.d/
 			rm -rf fail2ban/inst/$fail2ban_version
 			[[ -z $(grep fail2ban /etc/rc.local) ]] && sed -i '/^exit 0/i\test -d /var/run/fail2ban || install -m 755 -d /var/run/fail2ban/' /etc/rc.local
 			mkdir /var/run/fail2ban/ 2> /dev/null
@@ -621,6 +624,11 @@ A backup will be stored in ./before_upgrade_$timestamp
 	returnwait "Rsyslogd configuration" "Fail2ban configuration"
 
 	installtask fail2ban
+	# restore user configuration (*.local)
+	cp before_upgrade_$timestamp/fail2ban/*.local /etc/fail2ban/
+	cp before_upgrade_$timestamp/fail2ban/action.d/*.local /etc/fail2ban/action.d/
+	cp before_upgrade_$timestamp/fail2ban/filter.d/*.local /etc/fail2ban/filter.d/
+	cp before_upgrade_$timestamp/fail2ban/jail.d/*.local /etc/fail2ban/jail.d/
 	returnwait "Fail2ban configuration" "Restarting services"
 
 	installtask restartservices

--- a/spamassassin/conf/spamlearn
+++ b/spamassassin/conf/spamlearn
@@ -1,13 +1,23 @@
 #!/bin/bash
 PATH=/usr/local/bin:/usr/local/sbin:/sbin:/usr/sbin:/bin:/usr/bin:/usr/bin/X11
 
-for domain in $(ls /var/vmail); do
-	if [[ $domain != "vfilter" && $domain != "sieve" && -d /var/vmail/$domain ]]; then
-		for user in $(ls /var/vmail/$domain); do
-			[[ -d "/var/vmail/$domain/$user/.Junk/cur" ]] && sa-learn --dbpath /var/lib/spamassassin/.spamassassin --no-sync --spam /var/vmail/$domain/$user/.Junk/cur > /dev/null
-			[[ -d "/var/vmail/$domain/$user/cur" ]] && sa-learn --dbpath /var/lib/spamassassin/.spamassassin --no-sync --ham /var/vmail/$domain/$user/cur > /dev/null
+VMAILDIR="/var/vmail"
+SADB="/var/lib/spamassassin/.spamassassin"
+
+for domain in $(ls ${VMAILDIR}); do
+	if [[ $domain != "vfilter" && $domain != "sieve" && -d "${VMAILDIR}/${domain}" ]]; then
+		for user in $(ls ${VMAILDIR}/${domain}); do
+			# TODO: delete old emails in spam: find ${VMAILDIR}/${domain}/${user}/.Junk/cur -regex '.*' -ctime +28 -type f -delete
+			if [[ -d "${VMAILDIR}/${domain}/${user}/.Junk/cur" ]]; then
+				SPAMCOUNT=$(find ${VMAILDIR}/${domain}/${user}/.Junk/cur -regex '.*' -type f | wc -l)
+				[[ $SPAMCOUNT -ge 1 ]] && sa-learn --dbpath ${SADB} --no-sync --spam ${VMAILDIR}/${domain}/${user}/.Junk/cur > /dev/null
+			fi
+			if [[ -d "${VMAILDIR}/${domain}/${user}/cur" ]]; then
+				HAMCOUNT=$(find ${VMAILDIR}/${domain}/${user}/cur -regex '.*' -type f | wc -l)
+				[[ $HAMCOUNT -ge 1 ]] && sa-learn --dbpath ${SADB} --no-sync --ham ${VMAILDIR}/${domain}/${user}/cur > /dev/null
+			fi
 		done
 	fi
 done
-sa-learn --dbpath /var/lib/spamassassin/.spamassassin --sync > /dev/null
-chown -R debian-spamd: /var/lib/spamassassin/.spamassassin
+sa-learn --dbpath ${SADB} --sync > /dev/null
+chown -R debian-spamd: ${SADB}


### PR DESCRIPTION
roundcube: using the update tool of roundcube saves user changes, so y not use it?
fail2ban: to keep user changes moving default config to jail.d/*.conf and on update, restore *.local
spamassassin: check if there are emails to learn, otherwise do nothing
