### PR TITLE
[WIP] Add correct validation for domain-names/emails

### DIFF
--- a/webserver/htdocs/mail/do.php
+++ b/webserver/htdocs/mail/do.php
@@ -329,7 +329,7 @@ while ($row = mysqli_fetch_array($result)) {
 	<?php
 	}
 	elseif (isset($_GET['editdomain'])) {
-		if (!ctype_alnum(str_replace(array('.', '-'), '', $_GET["editdomain"])) || empty($_GET["editdomain"])) { 
+		if (!filter_var($_GET["editdomain"], FILTER_VALIDATE_DOMAIN) || empty($_GET["editdomain"])) {
 			echo 'Your provided domain name is invalid.';
 		}
 		else {
@@ -456,7 +456,7 @@ while ($row = mysqli_fetch_array($result)) {
 		}
 	}
 	elseif (isset($_GET["deletedomain"])) {
-		if(!ctype_alnum(str_replace(array('.', '-'), '', $_GET["deletedomain"])) || empty($_GET["deletedomain"])) { 
+		if(!filter_var($_GET["deletedomain"], FILTER_VALIDATE_DOMAIN) || empty($_GET["deletedomain"])) {
 			echo 'Your provided domain name is invalid.';
 		}
 		else {
@@ -517,7 +517,7 @@ while ($row = mysqli_fetch_array($result)) {
 		}
 	}
 	elseif (isset($_GET["deletealiasdomain"])) {
-		if (!ctype_alnum(str_replace(array('.', '-'), '', $_GET["deletealiasdomain"])) || empty($_GET["deletealiasdomain"])) {
+		if (!filter_var($_GET["deletealiasdomain"], FILTER_VALIDATE_DOMAIN) || empty($_GET["deletealiasdomain"])) {
 			header("Location: do.php?event=".base64_encode("Alias domain name invalid"));
 			die("Alias domain name invalid");
 		}

--- a/webserver/htdocs/mail/do.php
+++ b/webserver/htdocs/mail/do.php
@@ -329,7 +329,7 @@ while ($row = mysqli_fetch_array($result)) {
 	<?php
 	}
 	elseif (isset($_GET['editdomain'])) {
-		if (!filter_var($_GET["editdomain"], FILTER_VALIDATE_DOMAIN) || empty($_GET["editdomain"])) {
+		if (!is_valid_domain_name($_GET["editdomain"]) || empty($_GET["editdomain"])) {
 			echo 'Your provided domain name is invalid.';
 		}
 		else {
@@ -456,7 +456,7 @@ while ($row = mysqli_fetch_array($result)) {
 		}
 	}
 	elseif (isset($_GET["deletedomain"])) {
-		if(!filter_var($_GET["deletedomain"], FILTER_VALIDATE_DOMAIN) || empty($_GET["deletedomain"])) {
+		if(!is_valid_domain_name($_GET["deletedomain"]) || empty($_GET["deletedomain"])) {
 			echo 'Your provided domain name is invalid.';
 		}
 		else {
@@ -517,7 +517,7 @@ while ($row = mysqli_fetch_array($result)) {
 		}
 	}
 	elseif (isset($_GET["deletealiasdomain"])) {
-		if (!filter_var($_GET["deletealiasdomain"], FILTER_VALIDATE_DOMAIN) || empty($_GET["deletealiasdomain"])) {
+		if (!is_valid_domain_name($_GET["deletealiasdomain"]) || empty($_GET["deletealiasdomain"])) {
 			header("Location: do.php?event=".base64_encode("Alias domain name invalid"));
 			die("Alias domain name invalid");
 		}

--- a/webserver/htdocs/mail/inc/functions.inc.php
+++ b/webserver/htdocs/mail/inc/functions.inc.php
@@ -1183,5 +1183,10 @@ function delete_domain_admin($link, $postarray) {
 	}
 	header('Location: do.php?return=success');
 }
+function is_valid_domain_name($domainName) {
+	return (preg_match("/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i", $domain_name)
+		   && preg_match("/^.{1,253}$/", $domain_name)
+		   && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domain_name));
+}
 ?>
 


### PR DESCRIPTION
This is a Work in Progress (WIP).

This adds the validation for domain-names and e-mail addresses via `filter_var()`.

I'm not sure, if `FILTER_VALIDATE_DOMAIN` is available via PHP - the docs don't mention this flag - but it's available in PHP's source code ([here](https://github.com/php/php-src/blob/0437aa2abf1eb494e4555d7d4dfbdbf566a59bdc/ext/filter/logical_filters.c#L509)). I'm investigation this later. 

Mentioned here: #79 #62 

THE CHANGES ARE UNTESTED YET - DO NOT MERGE!