### PR TITLE
Create /var/www/ during installation.

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -398,6 +398,7 @@ DatabaseMirror clamav.inode.at" >> /etc/clamav/freshclam.conf
 		webserver)
 			# Testing: Keep added files
 			#rm -rf /var/www/{mail,dav} 2> /dev/null
+			mkdir -p /var/www/
 			if [[ ${conf_httpd} == "nginx" ]]; then
 				rm /etc/nginx/sites-enabled/{000-0-mailcow,000-0-fufix} 2>/dev/null
 				cp webserver/nginx/conf/sites-available/mailcow /etc/nginx/sites-available/


### PR DESCRIPTION
This fixes issue #66. The /var/www/ directory gets created before copying the htdocs files.

Although I just realised I tested with an oldstable image (7.8). Maybe this error doesn't happen with the stable distribution. But this additional instruction won't hurt anyway.