### PR TITLE
propper mx backup handling

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -292,6 +292,7 @@ DEBIAN_FRONTEND=noninteractive apt-get --force-yes -y install dovecot-common dov
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_alias_domain_mailbox_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_alias_domain_mailbox_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_mailbox_limit_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_mailbox_limit_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_mailbox_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_mailbox_maps.cf"
+			chown root:postfix "/etc/postfix/sql/mysql_virtual_mxmailbox_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_mxmailbox_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_alias_domain_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_alias_domain_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_spamalias_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_spamalias_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_domains_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_domains_maps.cf"
@@ -308,6 +309,7 @@ DEBIAN_FRONTEND=noninteractive apt-get --force-yes -y install dovecot-common dov
 			sed -i "s/my_mailcowdb/$my_mailcowdb/g" /etc/postfix/sql/* /etc/cron.daily/mc_clean_spam_aliases
 			sed -i "s/my_dbhost/$my_dbhost/g" /etc/postfix/sql/* /etc/cron.daily/mc_clean_spam_aliases
 			postmap /etc/postfix/mailcow_sender_access
+			postmap /etc/postfix/relay_recipients
 			chown www-data: /etc/postfix/mailcow_*
 			chmod 755 /var/spool/
 			sed -i "/%www-data/d" /etc/sudoers 2> /dev/null

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -292,7 +292,7 @@ DEBIAN_FRONTEND=noninteractive apt-get --force-yes -y install dovecot-common dov
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_alias_domain_mailbox_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_alias_domain_mailbox_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_mailbox_limit_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_mailbox_limit_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_mailbox_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_mailbox_maps.cf"
-			chown root:postfix "/etc/postfix/sql/mysql_virtual_mxmailbox_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_mxmailbox_maps.cf"
+			chown root:postfix "/etc/postfix/sql/mysql_virtual_mxdomain_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_mxdomain_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_alias_domain_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_alias_domain_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_spamalias_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_spamalias_maps.cf"
 			chown root:postfix "/etc/postfix/sql/mysql_virtual_domains_maps.cf"; chmod 640 "/etc/postfix/sql/mysql_virtual_domains_maps.cf"

--- a/postfix/conf/main.cf
+++ b/postfix/conf/main.cf
@@ -97,7 +97,7 @@ mydestination = MAILCOW_HOST.MAILCOW_DOMAIN, localhost.MAILCOW_DOMAIN, localhost
 relayhost =
 
 # We relay for those domains
-relay_domains= proxy:mysql:/etc/postfix/sql/mysql_virtual_alias_domain_maps.cf
+relay_domains= proxy:mysql:/etc/postfix/sql/mysql_virtual_mxdomain_maps.cf
 
 # Relay only for this accounts
 relay_recipient_maps = hash:/etc/postfix/relay_recipients

--- a/postfix/conf/main.cf
+++ b/postfix/conf/main.cf
@@ -96,6 +96,12 @@ mydestination = MAILCOW_HOST.MAILCOW_DOMAIN, localhost.MAILCOW_DOMAIN, localhost
 # We lookup MX records to send non-local mail, so this stays empty
 relayhost =
 
+# We relay for those domains
+relay_domains= proxy:mysql:/etc/postfix/sql/mysql_virtual_alias_domain_maps.cf
+
+# Relay only for this accounts
+relay_recipient_maps = hash:/etc/postfix/relay_recipients
+
 # Trusted SMTP clients with more privileges. Trusted clients can relay mail.
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 
@@ -231,4 +237,3 @@ postscreen_cache_map = proxy:btree:$data_directory/postscreen_cache
 # We need milter support for OpenDKIM
 milter_protocol = 6
 milter_default_action = accept
-

--- a/postfix/conf/relay_recipients
+++ b/postfix/conf/relay_recipients
@@ -1,0 +1,7 @@
+# relay all emails for the domain
+# @example.de     OK
+# relay only for one mail address
+# user@example.de   OK
+# reject one user, relay the rest (the correct sequence is important!)
+# user@example.de   REJECT
+# @example.de       OK

--- a/postfix/conf/sql/mysql_virtual_domains_maps.cf
+++ b/postfix/conf/sql/mysql_virtual_domains_maps.cf
@@ -3,9 +3,8 @@ user = my_mailcowuser
 password = my_mailcowpass
 hosts = my_dbhost
 dbname = my_mailcowdb
-query          = SELECT domain FROM domain WHERE domain='%s' AND active = '1'
+#query          = SELECT domain FROM domain WHERE domain='%s' AND active = '1'
 #query          = SELECT domain FROM domain WHERE domain='%s'
 #optional query to use when relaying for backup MX
-#query           = SELECT domain FROM domain WHERE domain='%s' AND backupmx = '0' AND active = '1'
+query           = SELECT domain FROM domain WHERE domain='%s' AND backupmx = '0' AND active = '1'
 #expansion_limit = 100
-

--- a/postfix/conf/sql/mysql_virtual_mxdomain_maps.cf
+++ b/postfix/conf/sql/mysql_virtual_mxdomain_maps.cf
@@ -1,0 +1,7 @@
+# mysql_virtual_domains_maps.cf
+user = my_mailcowuser
+password = my_mailcowpass
+hosts = my_dbhost
+dbname = my_mailcowdb
+#query           = SELECT domain FROM domain WHERE domain='%s' AND backupmx = '1' AND active = '1'
+#expansion_limit = 100

--- a/postfix/conf/sql/mysql_virtual_mxmailbox_maps.cf
+++ b/postfix/conf/sql/mysql_virtual_mxmailbox_maps.cf
@@ -1,0 +1,7 @@
+# mysql_virtual_mailbox_maps.cf
+user = my_mailcowuser
+password = my_mailcowpass
+hosts = my_dbhost
+dbname = my_mailcowdb
+query           = SELECT maildir FROM mailbox WHERE username='%s' AND backupmx = '1' AND active = '1'
+#expansion_limit = 100

--- a/postfix/conf/sql/mysql_virtual_mxmailbox_maps.cf
+++ b/postfix/conf/sql/mysql_virtual_mxmailbox_maps.cf
@@ -1,7 +1,0 @@
-# mysql_virtual_mailbox_maps.cf
-user = my_mailcowuser
-password = my_mailcowpass
-hosts = my_dbhost
-dbname = my_mailcowdb
-query           = SELECT maildir FROM mailbox WHERE username='%s' AND backupmx = '1' AND active = '1'
-#expansion_limit = 100


### PR DESCRIPTION
this commit will fix mx backup.

MX backup is currently not working, as "relay_domains" is unset.

- Added mysql query on "relay_domains" for mx domains
- Added a "relay_recipients"-list to setup what addresses are relayed (you may want to implement this in the mailcow gui?!)
- Changed mysql query for final destination domains 
