### PR TITLE
Master

### DIFF
--- a/dovecot/conf/dovecot.conf
+++ b/dovecot/conf/dovecot.conf
@@ -16,6 +16,7 @@ ssl_cipher_list = EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECD
 # Automatically regenerates every week
 ssl_dh_parameters_length = 2048
 log_timestamp = "%Y-%m-%d %H:%M:%S "
+recipient_delimiter = +
 passdb {
   args = /etc/dovecot/dovecot-mysql.conf
   driver = sql
@@ -150,7 +151,6 @@ plugin {
   sieve_max_script_size = 1M
   sieve_quota_max_scripts = 0
   sieve_quota_max_storage = 0
-  recipient_delimiter = +
 }
 dict {
   sqlquota = mysql:/etc/dovecot/dovecot-dict-sql.conf


### PR DESCRIPTION
recipient_delimiter does not work when running in plugin() context

I am not sure if it always has to be declared in the „root document“ part. But it did not work on my fresh 0.11 install until I moved it out of the plugin() context. 