### PR TITLE
Updated mc_size_size to support apache 

### DIFF
--- a/misc/mc_msg_size
+++ b/misc/mc_msg_size
@@ -10,6 +10,8 @@ echo "Parameter must be a value in MB."
 exit 1
 fi
 
+if [ -f /etc/nginx/sites-available/mailcow ]; then
+#Nginx
 sed -i "/upload_max_filesize/c\php_admin_value[upload_max_filesize] = ${1}M" /etc/php5/fpm/pool.d/mail.conf
 sed -i "/post_max_size/c\php_admin_value[post_max_size] = $(expr $1 + 1)M" /etc/php5/fpm/pool.d/mail.conf
 [[ -f /etc/nginx/nginx.conf ]] && sed -i "s/client_max_body_size.*/client_max_body_size ${1}m;/g" $(grep -lr "mailcow site configuration" /etc/nginx/sites-available/)
@@ -19,3 +21,18 @@ echo "Reloading services..."
 postfix reload
 [[ -f $(which nginx) ]] && nginx -s reload
 service php5-fpm reload
+
+elif [ -f /etc/apache2/sites-available/mailcow ]; then
+#Apache
+sed -i "/upload_max_filesize/c\php_value upload_max_filesize ${1}M" /etc/apache2/sites-available/mailcow
+sed -i "/post_max_size/c\php_value post_max_size $(expr $1 + 1)M"  /etc/apache2/sites-available/mailcow
+sed -i "s/message_size_limit.*/message_size_limit = $(( $1 * 1048576 ))/g" /etc/postfix/main.cf
+
+echo "Reloading services..."
+postfix reload
+service apache2 reload
+
+else
+echo "Error Unknown Config"
+exit 1
+fi

--- a/webserver/apache2/conf/sites-available/mailcow
+++ b/webserver/apache2/conf/sites-available/mailcow
@@ -30,6 +30,9 @@
 		SSLCertificateFile /etc/ssl/mail/mail.crt
 		SSLCertificateKeyFile /etc/ssl/mail/mail.key
 		ErrorDocument 503 /admin.php
+		php_value upload_max_filesize 25M
+                php_value post_max_size 26M
+
         ErrorDocument 500 /admin.php
 		<FilesMatch "\.(cgi|shtml|phtml|php)$">
 			SSLOptions +StdEnvVars


### PR DESCRIPTION
Hi i've updated mc_size_size to add support for changing upload_max_filesize and post_max_size of apache since the current version doesn't work any more for apache since the config is now  using mod_php instead of php-fpm, i also have to update apache config a bit to be able to change the php setting 