### PR TITLE
Fixed setting date.timezone in apache config

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -447,7 +447,7 @@ DatabaseMirror clamav.inode.at" >> /etc/clamav/freshclam.conf
 				sed -i "s/\"\MAILCOW_DAV_HOST.MAILCOW_DOMAIN\"/\"${httpd_dav_subdomain}.${sys_domain}\"/g" /etc/apache2/sites-available/mailcow
 				sed -i "s/\"autoconfig.MAILCOW_DOMAIN\"/\"autoconfig.${sys_domain}\"/g" /etc/apache2/sites-available/mailcow
 				sed -i "s/MAILCOW_DOMAIN\"/${sys_domain}\"/g" /etc/apache2/sites-available/mailcow
-				sed -i "s/MAILCOW_TZ/\"${sys_timezone}\"/g" /etc/apache2/sites-available/mailcow
+				 sed -i "/date.timezone/c\php_value date.timezone ${sys_timezone}" /etc/apache2/sites-available/mailcow
 				a2enmod rewrite ssl > /dev/null 2>&1
 			fi
 			mkdir /var/lib/php5/sessions 2> /dev/null


### PR DESCRIPTION
Current version causes a sed: -e expression #1, char 22: unknown option to `s' error