### PR TITLE
Use example.com instead of domain.tld

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A summary of what software is installed with which features enabled.
 * Learn ham and spam, [Heinlein Support](https://www.heinlein-support.de/) SA rules included
 * Fail2ban brute force protection
 * A "mailcow control center" via browser: Add domains, mailboxes, aliases and more
-* Tagged mail like "username+tag@domain.tld" will be moved to folder "tag"
+* Tagged mail like "username+tag@example.com" will be moved to folder "tag"
 * Advanced ClamAV filters (ClamAV can be turned off, quarantined items can be downloaded)
 
 **Postfix**
@@ -147,7 +147,7 @@ Please contact me when you need help or found a bug.
 
 More debugging is about to come. Though everything should work as intended.
 
-After the installation, visit your dashboard @ **https://hostname.domain.tld**, use the logged credentials in `./installer.log`
+After the installation, visit your dashboard @ **https://hostname.example.com**, use the logged credentials in `./installer.log`
 
 Remember to create an alias- or a mailbox for Postmaster. ;-)
 

--- a/mailcow.config
+++ b/mailcow.config
@@ -2,7 +2,7 @@
 # Your servers new hostname and timezone.
 # FQDN will be "sys_hostname.sys_domain"
 # Example for valid timezone data: https://www.vmware.com/support/developer/vc-sdk/visdk400pubs/ReferenceGuide/timezone.html
-# If you plan to use "@sub.domain.tld" as mail domain, do NOT use "sub" as hostname!
+# If you plan to use "@sub.example.com" as mail domain, do NOT use "sub" as hostname!
 # ==================================
 
 sys_hostname="mail"

--- a/roundcube/conf/plugins/managesieve/config.inc.php
+++ b/roundcube/conf/plugins/managesieve/config.inc.php
@@ -9,7 +9,7 @@ $config['managesieve_port'] = null;
 // %h - user's IMAP hostname
 // %n - http hostname ($_SERVER['SERVER_NAME'])
 // %d - domain (http hostname without the first part)
-// For example %n = mail.domain.tld, %d = domain.tld
+// For example %n = mail.example.com, %d = example.com
 $config['managesieve_host'] = 'localhost';
 
 // authentication method. Can be CRAM-MD5, DIGEST-MD5, PLAIN, LOGIN, EXTERNAL

--- a/webserver/htdocs/mail/add.php
+++ b/webserver/htdocs/mail/add.php
@@ -82,7 +82,7 @@ if (isset($_SESSION['mailcow_cc_loggedin']) &&
 				<h4>Add alias</h4>
 				<form class="form-horizontal" role="form" method="post">
 					<div class="form-group">
-						<label class="control-label col-sm-2" for="address">Alias address(es) <small>(full email address OR @domain.tld for <span style='color:#ec466a'>catch-all</span>)</small> - comma separated:</label>
+						<label class="control-label col-sm-2" for="address">Alias address(es) <small>(full email address OR @example.com for <span style='color:#ec466a'>catch-all</span>)</small> - comma separated:</label>
 						<div class="col-sm-10">
 							<textarea class="form-control" rows="5" name="address"></textarea>
 						</div>

--- a/webserver/htdocs/mail/admin.php
+++ b/webserver/htdocs/mail/admin.php
@@ -536,15 +536,15 @@ nano /opt/vfilter/replies
 ; mailcow comes with plugins helping to export Cal- and CardDAV data to .vcf and .ics files.
 ; Each user can export data he has access to.
 ; You can generate these exports by finding a url to your calendar, and adding ?export at the end of the url. This will automatically trigger a download:
-https://<?=$DAV_SUBDOMAIN.$MYHOSTNAME_1.$MYHOSTNAME_2;?>/calendars/you@domain.tld/default?export
+https://<?=$DAV_SUBDOMAIN.$MYHOSTNAME_1.$MYHOSTNAME_2;?>/calendars/you@example.com/default?export
 
 ; The same procedure for address books:
-https://<?=$DAV_SUBDOMAIN.$MYHOSTNAME_1.$MYHOSTNAME_2;?>/addressbooks/you@domain.tld/default?export
+https://<?=$DAV_SUBDOMAIN.$MYHOSTNAME_1.$MYHOSTNAME_2;?>/addressbooks/you@example.com/default?export
 
 ; Please use a Cal-/CardDAV client of your choice to find out the URI of self-created calendars and address books.
 ; Administrators can use MySQL to find a users calendar and address book URI:
-mysql --defaults-file=/etc/mysql/debian.cnf mailcow_database_name -e "SELECT uri FROM calendars where principaluri='principals/you@domain.tld';"
-mysql --defaults-file=/etc/mysql/debian.cnf mailcow_database_name -e "SELECT uri FROM addressbooks where principaluri='principals/you@domain.tld';"
+mysql --defaults-file=/etc/mysql/debian.cnf mailcow_database_name -e "SELECT uri FROM calendars where principaluri='principals/you@example.com';"
+mysql --defaults-file=/etc/mysql/debian.cnf mailcow_database_name -e "SELECT uri FROM addressbooks where principaluri='principals/you@example.com';"
 </pre></div>
 
 <p data-toggle="collapse" style="cursor:help;" data-target="#debugging"><strong>Debugging</strong></p>


### PR DESCRIPTION
As described in RFC 2606 and RFC 6761, a number of domains such as example.com and example.org are maintained for documentation purposes.

These domains should be used as illustrative examples in documents as they are not available for registration or transfer.

There is a risk that someone will register domain.tld in  the future.