### PR TITLE
implements Mozilla Thunderbird Autoconfiguration

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -492,6 +492,8 @@ DatabaseMirror clamav.inode.at" >> /etc/clamav/freshclam.conf
 			sed -i "/date_default_timezone_set/c\date_default_timezone_set('${sys_timezone}');" /var/www/dav/server.php
 			touch /var/mailcow/mailbox_backup_env
 			echo none > /var/mailcow/log/pflogsumm.log
+			sed -i "s/MAILCOW_HOST.MAILCOW_DOMAIN/${sys_hostname}.${sys_domain}/g" /var/www/mail/autoconfig/mail/config-v1.1.xml
+			sed -i "s/MAILCOW_DOMAIN/${sys_domain}/g" /var/www/mail/autoconfig/mail/config-v1.1.xml
 			sed -i "s/my_dbhost/${my_dbhost}/g" /var/www/mail/inc/vars.inc.php /var/www/dav/server.php
 			sed -i "s/my_mailcowpass/${my_mailcowpass}/g" /var/www/mail/inc/vars.inc.php /var/www/dav/server.php
 			sed -i "s/my_mailcowuser/${my_mailcowuser}/g" /var/www/mail/inc/vars.inc.php /var/www/dav/server.php
@@ -613,6 +615,7 @@ $(textb "mailcow MySQL")          ${my_mailcowuser}:${my_mailcowpass}@${my_dbhos
 $(textb "Roundcube MySQL")        ${my_rcuser}:${my_rcpass}@${my_dbhost}/${my_rcdb}
 $(textb "Web server")             ${httpd_platform^}
 $(textb "Web root")               https://${sys_hostname}.${sys_domain}
+$(textb "Autoconfig (Mozilla)")   https://autoconfig.${sys_domain}
 $(textb "DAV web root")           https://${httpd_dav_subdomain}.${sys_domain}
 
 --------------------------------------------------------

--- a/webserver/apache2/conf/sites-available/mailcow.conf
+++ b/webserver/apache2/conf/sites-available/mailcow.conf
@@ -19,6 +19,16 @@ Listen 127.0.0.1:81
 	RewriteCond %{HTTPS} !=on
 	RewriteRule ^/?(.*) https://%{HTTP_HOST}/$1 [L,R,NE]
 </VirtualHost>
+<VirtualHost *:80>
+	ServerSignature off
+	TraceEnable off
+	AddDefaultCharset utf-8
+	ServerName "autoconfig.MAILCOW_DOMAIN"
+	DocumentRoot /var/www/mail/autoconfig
+	<Directory /var/www/mail/autoconfig>
+		Options -Indexes
+	</Directory>
+</VirtualHost>
 <IfModule mod_ssl.c>
 	<VirtualHost *:443>
 		ServerSignature off

--- a/webserver/htdocs/mail/autoconfig/mail/config-v1.1.xml
+++ b/webserver/htdocs/mail/autoconfig/mail/config-v1.1.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+
+<!-- Mozilla Thunderbird Autoconfiguration file provided by mailcow
+
+     Further reading:
+     https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration
+     https://wiki.mozilla.org/Thunderbird:Autoconfiguration
+     https://wiki.mozilla.org/Thunderbird:Autoconfiguration:ConfigFileFormat
+-->
+
+<clientConfig version="1.1">
+    <emailProvider id="MAILCOW_DOMAIN">
+      <domain>MAILCOW_DOMAIN</domain>
+
+      <displayName>MAILCOW_DOMAIN mail server powered by mailcow</displayName>
+      <displayShortName>MAILCOW_DOMAIN mail server</displayShortName>
+
+      <incomingServer type="imap">
+         <hostname>MAILCOW_HOST.MAILCOW_DOMAIN</hostname>
+         <port>993</port>
+         <socketType>SSL</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>password-cleartext</authentication>
+      </incomingServer>
+      <incomingServer type="imap">
+         <hostname>MAILCOW_HOST.MAILCOW_DOMAIN</hostname>
+         <port>143</port>
+         <socketType>STARTTLS</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>password-cleartext</authentication>
+      </incomingServer>
+
+      <incomingServer type="pop3">
+         <hostname>MAILCOW_HOST.MAILCOW_DOMAIN</hostname>
+         <port>995</port>
+         <socketType>SSL</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>password-cleartext</authentication>
+      </incomingServer>
+      <incomingServer type="pop3">
+         <hostname>MAILCOW_HOST.MAILCOW_DOMAIN</hostname>
+         <port>110</port>
+         <socketType>STARTTLS</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>password-cleartext</authentication>
+      </incomingServer>
+
+      <outgoingServer type="smtp">
+         <hostname>MAILCOW_HOST.MAILCOW_DOMAIN</hostname>
+         <port>465</port>
+         <socketType>SSL</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>password-cleartext</authentication>
+      </outgoingServer>
+
+      <outgoingServer type="smtp">
+         <hostname>MAILCOW_HOST.MAILCOW_DOMAIN</hostname>
+         <port>587</port>
+         <socketType>STARTTLS</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>password-cleartext</authentication>
+      </outgoingServer>
+
+      <enable visiturl="https://MAILCOW_HOST.MAILCOW_DOMAIN/admin.php">
+         <instruction>If you didn't change the password given to you by the administrator or if you didn't change it in a long time, please consider doing that now.</instruction>
+         <instruction lang="de">Sollten Sie das Ihnen durch den Administrator vergebene Passwort noch nicht geändert haben, empfehlen wir dies nun zu tun. Auch ein altes Passwort sollte aus Sicherheitsgründen geändert werden.</instruction>
+      </enable>
+
+      <documentation url="http://MAILCOW_HOST.MAILCOW_DOMAIN">
+         <descr lang="en">MAILCOW_DOMAIN mail server info</descr>
+         <descr lang="de">MAILCOW_DOMAIN Mailserver Info</descr>
+      </documentation>
+
+    </emailProvider>
+
+    <webMail>
+      <loginPage url="https://MAILCOW_HOST.MAILCOW_DOMAIN/rc/" />
+      <loginPageInfo url="https://MAILCOW_HOST.MAILCOW_DOMAIN/rc/">
+        <username>%EMAILADDRESS%</username>
+        <usernameField id="rcmloginuser" />
+        <passwordField id="rcmloginpwd" />
+        <loginButton id="rcmloginsubmit" />
+      </loginPageInfo>
+    </webMail>
+</clientConfig>

--- a/webserver/nginx/conf/sites-available/mailcow
+++ b/webserver/nginx/conf/sites-available/mailcow
@@ -17,6 +17,13 @@ server {
 	}
 }
 server {
+	listen 80;
+	listen [::]:80;
+	server_name autoconfig.MAILCOW_DOMAIN;
+	server_tokens off;
+	root /var/www/mail/autoconfig;
+}
+server {
 	listen 443;
 	listen [::]:443;
 	ssl on;


### PR DESCRIPTION
there was already an ´autoconfig.xml´ available but it is neither working (for me) nor is it following the definition provided by Mozilla, which is also expected by other clients:
- https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration
- https://wiki.mozilla.org/Thunderbird:Autoconfiguration
- https://wiki.mozilla.org/Thunderbird:Autoconfiguration:ConfigFileFormat

New settings tested on a productive system.
I did **not** test the installation but the changes in `functions.sh` are not really magic ;)
