### PR TITLE
Added a spamassassin/local.cf.include file

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -473,6 +473,9 @@ DatabaseMirror clamav.inode.at" >> /etc/clamav/freshclam.conf
 			;;
 		spamassassin)
 			cp spamassassin/conf/local.cf /etc/spamassassin/local.cf
+			if [[ ! -f /etc/spamassassin/local.cf.include ]]; then
+                        	cp spamassassin/conf/local.cf.include /etc/spamassassin/local.cf.include
+                        fi
 			sed -i '/^OPTIONS=/s/=.*/="--create-prefs --max-children 5 --helper-home-dir --username debian-spamd --socketpath \/var\/run\/spamd.sock --socketowner debian-spamd --socketgroup debian-spamd"/' /etc/default/spamassassin
 			sed -i '/^CRON=/s/=.*/="1"/' /etc/default/spamassassin
 			sed -i '/^ENABLED=/s/=.*/="1"/' /etc/default/spamassassin

--- a/spamassassin/conf/local.cf
+++ b/spamassassin/conf/local.cf
@@ -1,3 +1,5 @@
+# Do not put customisations into this file.  It will be overwitten by upgrades.
+# Add any customisations into local.cf.include in the same directory.
 report_safe 2
 required_score 5.0
 use_bayes 1
@@ -14,3 +16,4 @@ add_header all Status _YESNO_, score=_SCORE_ required=_REQD_ tests=_TESTS_ autol
 # Don't trust any network
 clear_internal_networks
 clear_internal_networks
+include local.cf.include

--- a/spamassassin/conf/local.cf.include
+++ b/spamassassin/conf/local.cf.include
@@ -1,0 +1,3 @@
+# Use this file to make changes to the spamassassin/local.cf
+# This file will not be overwritten by future upgrades.
+


### PR DESCRIPTION
Add a spamassassin/local.cf.include file so that people may add customisations without them being overridden on upgrade.

We have a few system logs that get emailed and keep getting marked as spam which we whitelist in the spamassassin/local.cf file.  This means we don't have to restore them each time we upgrade :-)