### PR TITLE
Enabling listescape plugin

### DIFF
--- a/dovecot/conf/dovecot.conf
+++ b/dovecot/conf/dovecot.conf
@@ -9,7 +9,7 @@ disable_plaintext_auth = yes
 login_log_format_elements = "user=<%u> method=%m rip=%r lip=%l mpid=%e %c %k"
 mail_home = /var/vmail/%d/%n
 mail_location = maildir:~/
-mail_plugins = quota acl fts fts_solr
+mail_plugins = quota acl fts fts_solr listescape
 auth_username_chars = abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890.-_@
 ssl_protocols = !SSLv3 !SSLv2
 ssl_cipher_list = EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA
@@ -130,10 +130,10 @@ userdb {
   driver = sql
 }
 protocol imap {
-  mail_plugins = quota imap_quota imap_acl acl fts fts_solr
+  mail_plugins = quota imap_quota imap_acl acl fts fts_solr listescape
 }
 protocol lmtp {
-  mail_plugins = quota sieve acl fts fts_solr
+  mail_plugins = quota sieve acl fts fts_solr listescape
   auth_socket_path = /var/run/dovecot/auth-master
   postmaster_address = postmaster@MAILCOW_DOMAIN
 }


### PR DESCRIPTION
I encourage the usage of the dovecot plugin listescape, which allows to use invalid characters like "." in foldernames. This makes migration from existing mailservers to mailcow easier.
