### PR TITLE
Let users handle their subscriptions

### DIFF
--- a/dovecot/conf/dovecot.conf
+++ b/dovecot/conf/dovecot.conf
@@ -76,7 +76,7 @@ namespace {
     separator = /
     prefix = Shared/%%u/
     location = maildir:%%h/:INDEXPVT=~/Shared/%%u
-    subscriptions = yes
+    subscriptions = no
     list = yes
 }
 protocols = imap sieve lmtp pop3


### PR DESCRIPTION
> subscriptions: "yes" (default) if this namespace should handle its own subscriptions. If "no", then the first parent namespace with subscriptions=yes will handle it. For example if it's "no" for a namespace with prefix=foo/bar/, Dovecot first sees if there's a prefix=foo/ namespace with subscriptions=yes and then a namespace with an empty prefix. If neither is found, an error is given. 

This change fixes the subscriptions, so every user can change if he / she want some shared folders to be displayed or not.