### PR TITLE
4096 bits DH key instead of 2048 bits

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -267,7 +267,7 @@ DEBIAN_FRONTEND=noninteractive apt-get --force-yes -y install dovecot-common dov
 			mkdir /etc/ssl/mail 2> /dev/null
 			[[ $inst_keepfiles == "no" ]] && rm /etc/ssl/mail/* 2> /dev/null
 			echo "$(textb [INFO]) - Generating 2048 bit DH parameters, this may take a while, please wait..."
-			openssl dhparam -out /etc/ssl/mail/dhparams.pem 2048 2> /dev/null
+			openssl dhparam -out /etc/ssl/mail/dhparams.pem 4096 2> /dev/null
 			openssl req -new -newkey rsa:4096 -sha256 -days 1095 -nodes -x509 -subj "/C=ZZ/ST=mailcow/L=mailcow/O=mailcow/CN=${sys_hostname}.${sys_domain}/subjectAltName=DNS.1=${sys_hostname}.${sys_domain},DNS.2=autodiscover.{sys_domain}" -keyout /etc/ssl/mail/mail.key -out /etc/ssl/mail/mail.crt
 			chmod 600 /etc/ssl/mail/mail.key
 			cp /etc/ssl/mail/mail.crt /usr/local/share/ca-certificates/
@@ -709,7 +709,7 @@ A backup will be stored in ./before_upgrade_${timestamp}
 	fi
 	if [[ ! -f /etc/ssl/mail/dhparams.pem ]]; then
 		echo "$(textb [INFO]) - Generating 2048 bit DH parameters, this may take a while, please wait..."
-		openssl dhparam -out /etc/ssl/mail/dhparams.pem 2048 2> /dev/null
+		openssl dhparam -out /etc/ssl/mail/dhparams.pem 4096 2> /dev/null
 	fi
 
 	returnwait "Package installation"


### PR DESCRIPTION
Even NSA recommends 3072+ bits Diffie-Hellman key. 4096 bits DH does not have any impact on compatibility 