### PR TITLE
Mirror fix to commit 387644c

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -271,7 +271,7 @@ DEBIAN_FRONTEND=noninteractive ${APT} -y install dovecot-common dovecot-core dov
 			for oldfiles in /etc/cron.daily/mc_clean_spam_aliases /usr/local/sbin/mc_pflog_renew /usr/local/sbin/mc_msg_size /usr/local/sbin/mc_dkim_ctrl /usr/local/sbin/mc_resetadmin
 			do
 			if [ -f "$oldfiles" ] ; then
-			rm "$oldfile"
+			rm "$oldfiles"
 			fi
 			done
 			

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -267,6 +267,14 @@ solr-jetty > /dev/null
 			cp /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/dovecot/private/dovecot.pem
 			cp /etc/ssl/private/ssl-cert-snakeoil.key /etc/dovecot/private/dovecot.key
 DEBIAN_FRONTEND=noninteractive ${APT} -y install dovecot-common dovecot-core dovecot-imapd dovecot-lmtpd dovecot-managesieved dovecot-sieve dovecot-mysql dovecot-pop3d dovecot-solr >/dev/null
+			
+			for oldfiles in /etc/cron.daily/mc_clean_spam_aliases /usr/local/sbin/mc_pflog_renew /usr/local/sbin/mc_msg_size /usr/local/sbin/mc_dkim_ctrl /usr/local/sbin/mc_resetadmin
+			do
+			if [ -f "$oldfiles" ] ; then
+			rm "$oldfile"
+			fi
+			done
+			
 			install -m 755 misc/mailcow-clean-spam-aliases /etc/cron.daily/mailcow-clean-spam-aliases
 			install -m 755 misc/mailcow-renew-pflogsumm /usr/local/sbin/mailcow-renew-pflogsumm
 			install -m 755 misc/mailcow-set-message-limit /usr/local/sbin/mailcow-set-message-limit


### PR DESCRIPTION
Changing the files names will leave old files on upgraded install and cause clean_spam_aliases corn-job to run twice, not a major issue.