### PR TITLE
Remove weaker cipher suites for secure SMTP

### DIFF
--- a/postfix/conf/main.cf
+++ b/postfix/conf/main.cf
@@ -34,8 +34,8 @@ smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3
 smtpd_tls_protocols = !SSLv2, !SSLv3
 smtpd_tls_mandatory_ciphers=high
-smtpd_tls_exclude_ciphers = ECDHE-RSA-RC4-SHA
-smtpd_tls_mandatory_exclude_ciphers = ECDHE-RSA-RC4-SHA
+smtpd_tls_exclude_ciphers = ECDHE-RSA-RC4-SHA, RC4, aNULL
+smtpd_tls_mandatory_exclude_ciphers = ECDHE-RSA-RC4-SHA, RC4, aNULL
 
 # Log TLS handling
 smtpd_tls_loglevel = 1


### PR DESCRIPTION
Fixes #411.

Basically this pull request excludes some weaker and MITM-vulnerable cipher suites and gets rid of a warning that would be shown by SSL-Check due to the usage of those cipher suites.