### PR TITLE
add SRI for cloudflare scripts

### DIFF
--- a/webserver/htdocs/mail/admin.php
+++ b/webserver/htdocs/mail/admin.php
@@ -488,7 +488,7 @@ else {
 }
 ?>
 </div> <!-- /container -->
-<script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" integrity="sha384-YWP9O4NjmcGo4oEJFXvvYSEzuHIvey+LbXkBNJ1Kd0yfugEZN9NCQNpRYBVC1RvA" crossorigin="anonymous"></script>
 <script src="js/admin.js"></script>
 <?php
 require_once("inc/footer.inc.php");

--- a/webserver/htdocs/mail/inc/footer.inc.php
+++ b/webserver/htdocs/mail/inc/footer.inc.php
@@ -1,7 +1,7 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/js/bootstrap.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-switch/3.3.2/js/bootstrap-switch.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/7.0.2/bootstrap-slider.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.9.4/js/bootstrap-select.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-switch/3.3.2/js/bootstrap-switch.min.js" integrity="sha384-QIv8AGAxdI0cTHbmvoLkNuELOU7DQoz9LACnXQ61JsVJll396XlhlYsimV/19bJr" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/7.0.2/bootstrap-slider.min.js" integrity="sha384-zdPTsjljZsv2x02Dh9tJkwW1pVC3fUT0N1eWPzxmKQ5KiUPgE7I8L/Zvwq7624Ew" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.9.4/js/bootstrap-select.js" integrity="sha384-EW/AEsB10NrX7B55CM1thFvSw6+KfMAvsUYrqudLjOIXZUKQ0nJbQuiXAcZA/dfI" crossorigin="anonymous"></script>
 <script>
 // Select language and reopen active URL without POST
 function setLang(sel) {

--- a/webserver/htdocs/mail/inc/header.inc.php
+++ b/webserver/htdocs/mail/inc/header.inc.php
@@ -51,7 +51,7 @@ require_once 'inc/triggers.inc.php';
 <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.0/jquery.min.js" integrity="sha384-XxcvoeNF5V0ZfksTnV+bejnCsJjOOIzN6UVwF85WBsAnU3zeYh5bloN+L4WLgeNE" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css">
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/<?=strtolower(trim($DEFAULT_THEME));?>/bootstrap.min.css">
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.9.4/css/bootstrap-select.min.css" rel="stylesheet" />


### PR DESCRIPTION
Adds SRI for the externally loaded scripts. As recommended by:
https://observatory.mozilla.org

see also:
https://wiki.mozilla.org/Security/Guidelines/Web_Security#Subresource_Integrity

generated with:
https://www.srihash.org/