### PR TITLE
Increase webserver security by some headers and cookie directive

### DIFF
--- a/webserver/htdocs/mail/inc/header.inc.php
+++ b/webserver/htdocs/mail/inc/header.inc.php
@@ -1,5 +1,6 @@
 <?php
 ini_set("session.cookie_secure", 1);
+ini_set("session.cookie_httponly", 1);
 session_start();
 if (isset($_POST["logout"])) {
 	session_unset();

--- a/webserver/htdocs/mail/inc/header.inc.php
+++ b/webserver/htdocs/mail/inc/header.inc.php
@@ -1,4 +1,5 @@
 <?php
+ini_set("session.cookie_secure", 1);
 session_start();
 if (isset($_POST["logout"])) {
 	session_unset();

--- a/webserver/nginx/conf/sites-available/mailcow_rc
+++ b/webserver/nginx/conf/sites-available/mailcow_rc
@@ -38,6 +38,15 @@ server {
 	index index.html index.htm index.php;
 	error_page 502 /redir.html;
 
+	# Block site from being framed (Old style)
+	add_header X-Frame-Options "DENY";
+	# Block site from being framed (new  style by means of CSP)
+	add_header Content-Security-Policy "frame-ancestors 'none';";
+	# Prevent browsers from incorrectly detecting non-scripts as scripts
+	add_header X-Content-Type-Options nosniff;
+	# Block pages from loading when they detect reflected XSS attacks
+	add_header X-XSS-Protection "1; mode=block";
+
 	location /redir.html {
 		return 301 /admin.php;
 	}

--- a/webserver/nginx/conf/sites-available/mailcow_sogo
+++ b/webserver/nginx/conf/sites-available/mailcow_sogo
@@ -35,6 +35,15 @@ server {
 	index index.html index.htm index.php;
 	error_page 502 /redir.html;
 
+        # Block site from being framed (Old style)
+        add_header X-Frame-Options "DENY";
+        # Block site from being framed (new  style by means of CSP)
+        add_header Content-Security-Policy "frame-ancestors 'none';";
+        # Prevent browsers from incorrectly detecting non-scripts as scripts
+        add_header X-Content-Type-Options nosniff;
+        # Block pages from loading when they detect reflected XSS attacks
+        add_header X-XSS-Protection "1; mode=block";
+
 	location /redir.html {
 		return 301 /admin.php;
 	}


### PR DESCRIPTION
These settings (together with the already merged SRI) lift the [security rating](https://observatory.mozilla.org) from F to A :-)

Getting full points is, to the best of my knowledge, not possible unless no external javascript code is loaded by means of 'unsafe-eval' and 'unsafe-inline'. See also: https://wiki.mozilla.org/Security/Guidelines/Web_Security#Content_Security_Policy

