### PR TITLE
Add missing root directive to autodiscover server block (nginx & SOGo)

### DIFF
--- a/webserver/nginx/conf/sites-available/mailcow_sogo
+++ b/webserver/nginx/conf/sites-available/mailcow_sogo
@@ -37,6 +37,7 @@ server {
 	ssl_dhparam /etc/ssl/mail/dhparams.pem;
 	add_header Strict-Transport-Security max-age=15768000;
 	ssl_session_timeout 30m;
+	root /var/www/mail;
 	location ~ \.php$ {
 		include fastcgi_params;
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;


### PR DESCRIPTION
The ssl server block for autodiscover in the nginx SOGo config is missing the root directive.