### PR TITLE
Fixed add_header rc

### DIFF
--- a/webserver/nginx/conf/sites-available/mailcow_rc
+++ b/webserver/nginx/conf/sites-available/mailcow_rc
@@ -44,7 +44,9 @@ server {
 	error_page 502 /redir.html;
 
 	# Block site from being framed (Old style)
-	add_header X-Frame-Options "DENY";
+ 	add_header X-Frame-Options "SAMEORIGIN";
+ 	# Block site from being framed (new  style by means of CSP)
+ 	add_header Content-Security-Policy "frame-ancestors 'self';";
 	# Prevent browsers from incorrectly detecting non-scripts as scripts
 	add_header X-Content-Type-Options nosniff;
 	# Block pages from loading when they detect reflected XSS attacks


### PR DESCRIPTION
The current add_header X-Frame-Options "DENY"; causes Round cube not to work correctly and causing  the loading spin to show all the time.

Chrome error console
Refused to display 'https://mx-de.***.be/rc/skins/larry/watermark.html' in a frame because it set 'X-Frame-Options' to 'DENY'.

app.min.js?s=1477579486:121 Uncaught DOMException: Blocked a frame with origin "https://mx-de.****.be" from accessing a cross-origin frame.(…)

All I've done is changed  X-Frame-Options to SAMEORIGIN and re-added Content-Security-Policy but this time set frame-ancestors to  'self'

This fixes the issue with was caused by a earlier merged Pull Request #523 with the usage of X-Frame-Options "DENY";