### PR TITLE
Mailcow Filter Bug

### DIFF
--- a/webserver/htdocs/mail/js/mailbox.js
+++ b/webserver/htdocs/mail/js/mailbox.js
@@ -15,12 +15,12 @@ $(document).ready(function() {
 		filterTable: function(){
 			return this.each(function(){
 				$(this).on('keyup', function(e){
-					$('.filterTable_no_results').remove();
 					var $this = $(this),
                         search = $this.val().toLowerCase(),
                         target = $this.attr('data-filters'),
                         $target = $(target),
                         $rows = $target.find('tbody #data');
+					$target.find('tbody .filterTable_no_results').remove();
 					if(search == '') {
 						$target.find('tbody #no-data').show();
 						$rows.show();


### PR DESCRIPTION
This pull request fixes a bug in the javascript code that contains the filtering algorithm of the mailbox page. This fixes the deletion of all table row in all panels that has the class of "filterTable_no_results" whenever any filter text input field was modified. Hence we should expect that editing the filter text input field of a panel should not affect other panels.

> This bug also exists in mailcow 0.14 final and probably in older versions of mailcow. This isn't a major issue though.

Bug demo:
[![DEMO](https://img.youtube.com/vi/n3dwr_b9W4U/0.jpg)](https://www.youtube.com/watch?v=n3dwr_b9W4U)