### PR TITLE
Aligned table column headers

### DIFF
--- a/webserver/htdocs/mail/admin.php
+++ b/webserver/htdocs/mail/admin.php
@@ -70,10 +70,10 @@ if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == 'admi
 					<table class="table table-striped sortable-theme-bootstrap" data-sortable id="domainadminstable">
 						<thead>
 						<tr>
-							<th><?=$lang['admin']['username'];?></th>
-							<th><?=$lang['admin']['admin_domains'];?></th>
-							<th><?=$lang['admin']['active'];?></th>
-							<th data-sortable="false"><?=$lang['admin']['action'];?></th>
+							<th style="min-width: 100px;"><?=$lang['admin']['username'];?></th>
+							<th style="min-width: 166px;"><?=$lang['admin']['admin_domains'];?></th>
+							<th style="min-width: 76px;"><?=$lang['admin']['active'];?></th>
+							<th style="min-width: 100px;" data-sortable="false"><?=$lang['admin']['action'];?></th>
 						</tr>
 						</thead>
 						<tbody>

--- a/webserver/htdocs/mail/admin.php
+++ b/webserver/htdocs/mail/admin.php
@@ -73,7 +73,7 @@ if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == 'admi
 							<th style="min-width: 100px;"><?=$lang['admin']['username'];?></th>
 							<th style="min-width: 166px;"><?=$lang['admin']['admin_domains'];?></th>
 							<th style="min-width: 76px;"><?=$lang['admin']['active'];?></th>
-							<th style="min-width: 100px;" data-sortable="false"><?=$lang['admin']['action'];?></th>
+							<th style="min-width: 77px;" data-sortable="false"><?=$lang['admin']['action'];?></th>
 						</tr>
 						</thead>
 						<tbody>

--- a/webserver/htdocs/mail/mailbox.php
+++ b/webserver/htdocs/mail/mailbox.php
@@ -30,20 +30,20 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 				<table class="table table-striped sortable-theme-bootstrap" data-sortable id="domaintable">
 					<thead>
 						<tr>
-							<th><?=$lang['mailbox']['domain'];?></th>
-							<th><?=$lang['mailbox']['aliases'];?></th>
-							<th><?=$lang['mailbox']['mailboxes'];?></th>
-							<th><?=$lang['mailbox']['mailbox_quota'];?></th>
-							<th><?=$lang['mailbox']['domain_quota'];?></th>
+							<th style="min-width: 86px;"><?=$lang['mailbox']['domain'];?></th>
+							<th style="min-width: 81px;"><?=$lang['mailbox']['aliases'];?></th>
+							<th style="min-width: 99px;"><?=$lang['mailbox']['mailboxes'];?></th>
+							<th style="min-width: 172px;"><?=$lang['mailbox']['mailbox_quota'];?></th>
+							<th style="min-width: 117px;"><?=$lang['mailbox']['domain_quota'];?></th>
 							<?php
 							if ($_SESSION['mailcow_cc_role'] == "admin"):
 							?>
-								<th><?=$lang['mailbox']['backup_mx'];?></th>
+								<th style="min-width: 105px;"><?=$lang['mailbox']['backup_mx'];?></th>
 							<?php
 							endif;
 							?>
-							<th><?=$lang['mailbox']['active'];?></th>
-							<th data-sortable="false"><?=$lang['mailbox']['action'];?></th>
+							<th style="min-width: 76px;"><?=$lang['mailbox']['active'];?></th>
+							<th style="min-width: 77px;" data-sortable="false"><?=$lang['mailbox']['action'];?></th>
 						</tr>
 					</thead>
 					<tbody>
@@ -171,10 +171,10 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 				<table class="table table-striped sortable-theme-bootstrap" data-sortable id="domainaliastable">
 					<thead>
 						<tr>
-							<th><?=$lang['mailbox']['alias'];?></th>
-							<th><?=$lang['mailbox']['target_domain'];?></th>
-							<th><?=$lang['mailbox']['active'];?></th>
-							<th data-sortable="false"><?=$lang['mailbox']['action'];?></th>
+							<th style="min-width: 67px;"><?=$lang['mailbox']['alias'];?></th>
+							<th style="min-width: 127px;"><?=$lang['mailbox']['target_domain'];?></th>
+							<th style="min-width: 76px;"><?=$lang['mailbox']['active'];?></th>
+							<th style="min-width: 77px;" data-sortable="false"><?=$lang['mailbox']['action'];?></th>
 						</tr>
 					</thead>
 					<tbody>
@@ -252,14 +252,14 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 				<table class="table table-striped sortable-theme-bootstrap" data-sortable id="mailboxtable">
 					<thead>
 						<tr>
-							<th><?=$lang['mailbox']['username'];?></th>
-							<th><?=$lang['mailbox']['fname'];?></th>
-							<th><?=$lang['mailbox']['domain'];?></th>
-							<th><?=$lang['mailbox']['quota'];?></th>
-							<th><?=$lang['mailbox']['in_use'];?></th>
-							<th><?=$lang['mailbox']['msg_num'];?></th>
-							<th><?=$lang['mailbox']['active'];?></th>
-							<th data-sortable="false"><?=$lang['mailbox']['action'];?></th>
+							<th style="min-width: 100px;"><?=$lang['mailbox']['username'];?></th>
+							<th style="min-width: 98px;"><?=$lang['mailbox']['fname'];?></th>
+							<th style="min-width: 86px;"><?=$lang['mailbox']['domain'];?></th>
+							<th style="min-width: 75px;"><?=$lang['mailbox']['quota'];?></th>
+							<th style="min-width: 99px;"><?=$lang['mailbox']['in_use'];?></th>
+							<th style="min-width: 100px;"><?=$lang['mailbox']['msg_num'];?></th>
+							<th style="min-width: 76px;"><?=$lang['mailbox']['active'];?></th>
+							<th style="min-width: 77px;" data-sortable="false"><?=$lang['mailbox']['action'];?></th>
 						</tr>
 					</thead>
 					<tbody>
@@ -378,11 +378,11 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 				<table class="table table-striped sortable-theme-bootstrap" data-sortable id="aliastable">
 					<thead>
 						<tr>
-							<th><?=$lang['mailbox']['alias'];?></th>
-							<th><?=$lang['mailbox']['target_address'];?></th>
-							<th><?=$lang['mailbox']['domain'];?></th>
-							<th><?=$lang['mailbox']['active'];?></th>
-							<th data-sortable="false"><?=$lang['mailbox']['action'];?></th>
+							<th style="min-width: 67px;"><?=$lang['mailbox']['alias'];?></th>
+							<th style="min-width: 119px;"><?=$lang['mailbox']['target_address'];?></th>
+							<th style="min-width: 86px;"><?=$lang['mailbox']['domain'];?></th>
+							<th style="min-width: 76px;"><?=$lang['mailbox']['active'];?></th>
+							<th style="min-width: 77px;" data-sortable="false"><?=$lang['mailbox']['action'];?></th>
 						</tr>
 					</thead>
 					<tbody>

--- a/webserver/htdocs/mail/user.php
+++ b/webserver/htdocs/mail/user.php
@@ -67,8 +67,8 @@ if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == 'user
 <table class="table table-striped sortable-theme-bootstrap" data-sortable id="timelimitedaliases">
 	<thead>
 	<tr>
-		<th><?=$lang['user']['alias'];?></th>
-		<th><?=$lang['user']['alias_valid_until'];?></th>
+		<th style="min-width: 96px;"><?=$lang['user']['alias'];?></th>
+		<th style="min-width: 135px;"><?=$lang['user']['alias_valid_until'];?></th>
 	</tr>
 	</thead>
 	<tbody>


### PR DESCRIPTION
This PR fixes some dislocation of "::after" pseudo element in the tables on devices with small screen like mobile phones.