### PR TITLE
Language Switching is improved

### DIFF
--- a/webserver/htdocs/mail/inc/header.inc.php
+++ b/webserver/htdocs/mail/inc/header.inc.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="<?= $_SESSION['mailcow_locale'] ?>">
 <head>
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -37,80 +37,80 @@ ul[id$="sortable-inactive"] li {cursor:move }
 	background: #66CD00;
 }
 table[data-sortable] {
-  border-collapse: collapse;
-  border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 table[data-sortable] th {
-  vertical-align: bottom;
-  font-weight: bold;
+  vertical-align: bottom;
+  font-weight: bold;
 }
 table[data-sortable] th, table[data-sortable] td {
-  text-align: left;
-  padding: 10px;
+  text-align: left;
+  padding: 10px;
 }
 table[data-sortable] th:not([data-sortable="false"]) {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
-  user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  -webkit-touch-callout: none;
-  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-touch-callout: none;
+  cursor: pointer;
 }
 table[data-sortable] th:after {
-  content: "";
-  visibility: hidden;
-  display: inline-block;
-  vertical-align: inherit;
-  height: 0;
-  width: 0;
-  border-width: 5px;
-  border-style: solid;
-  border-color: transparent;
-  margin-right: 1px;
-  margin-left: 10px;
-  float: right;
+  content: "";
+  visibility: hidden;
+  display: inline-block;
+  vertical-align: inherit;
+  height: 0;
+  width: 0;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent;
+  margin-right: 1px;
+  margin-left: 10px;
+  float: right;
 }
 table[data-sortable] th[data-sortable="false"]:after {
-  display: none;
+  display: none;
 }
 table[data-sortable] th[data-sorted="true"]:after {
-  visibility: visible;
+  visibility: visible;
 }
 table[data-sortable] th[data-sorted-direction="descending"]:after {
-  border-top-color: inherit;
-  margin-top: 8px;
+  border-top-color: inherit;
+  margin-top: 8px;
 }
 table[data-sortable] th[data-sorted-direction="ascending"]:after {
-  border-bottom-color: inherit;
-  margin-top: 3px;
+  border-bottom-color: inherit;
+  margin-top: 3px;
 }
 table[data-sortable].sortable-theme-bootstrap thead th {
-  border-bottom: 2px solid #e0e0e0;
+  border-bottom: 2px solid #e0e0e0;
 }
 table[data-sortable].sortable-theme-bootstrap th[data-sorted="true"] {
-  color: #3a87ad;
-  background: #d9edf7;
-  border-bottom-color: #bce8f1;
+  color: #3a87ad;
+  background: #d9edf7;
+  border-bottom-color: #bce8f1;
 }
 table[data-sortable].sortable-theme-bootstrap th[data-sorted="true"][data-sorted-direction="descending"]:after {
-  border-top-color: #3a87ad;
+  border-top-color: #3a87ad;
 }
 table[data-sortable].sortable-theme-bootstrap th[data-sorted="true"][data-sorted-direction="ascending"]:after {
-  border-bottom-color: #3a87ad;
+  border-bottom-color: #3a87ad;
 }
 table[data-sortable].sortable-theme-bootstrap.sortable-theme-bootstrap-striped tbody > tr:nth-child(odd) > td {
-  background-color: #f9f9f9;
+  background-color: #f9f9f9;
 }
 .btn {
-   text-transform: none;
+   text-transform: none;
 }
 #data td, #no-data td {
 	vertical-align: middle;
 }
 .sort-table:hover {
-  border-bottom-color: #00B7DC !important;
+  border-bottom-color: #00B7DC !important;
 }
 </style>
 <?php
@@ -139,7 +139,7 @@ endif;
 ?>
 </head>
 <body style="padding-top:70px">
-<nav class="navbar navbar-default navbar-fixed-top"  role="navigation">
+<nav class="navbar navbar-default navbar-fixed-top"  role="navigation">
 	<div class="container-fluid">
 		<div class="navbar-header">
 			<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
@@ -158,9 +158,9 @@ endif;
 				<li class="dropdown">
 					<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="lang-sm lang-lbl" lang="<?=$_SESSION['mailcow_locale'];?>"></span><span class="caret"></span></a>
 					<ul class="dropdown-menu" role="menu">
-						<li <?=($_SESSION['mailcow_locale'] == 'de') ? 'class="active"' : ''?>> <a href="#" onClick="setLang('de')"><span class="lang-xs lang-lbl-full" lang="de"></span></a></li>
-						<li <?=($_SESSION['mailcow_locale'] == 'en') ? 'class="active"' : ''?>> <a href="#" onClick="setLang('en')"><span class="lang-xs lang-lbl-full" lang="en"></span></a></li>
-						<li <?=($_SESSION['mailcow_locale'] == 'pt') ? 'class="active"' : ''?>> <a href="#" onClick="setLang('pt')"><span class="lang-xs lang-lbl-full" lang="pt"></span></a></li>
+						<li <?=($_SESSION['mailcow_locale'] == 'de') ? 'class="active"' : ''?>> <a href="?<?= http_build_query(array_merge($_GET, array("lang" => "de"))) ?>"><span class="lang-xs lang-lbl-full" lang="de"></span></a></li>
+						<li <?=($_SESSION['mailcow_locale'] == 'en') ? 'class="active"' : ''?>> <a href="?<?= http_build_query(array_merge($_GET, array("lang" => "en"))) ?>"><span class="lang-xs lang-lbl-full" lang="en"></span></a></li>
+						<li <?=($_SESSION['mailcow_locale'] == 'pt') ? 'class="active"' : ''?>> <a href="?<?= http_build_query(array_merge($_GET, array("lang" => "pt"))) ?>"><span class="lang-xs lang-lbl-full" lang="pt"></span></a></li>
 					</ul>
 				</li>
 				<?php

--- a/webserver/htdocs/mail/inc/header.inc.php
+++ b/webserver/htdocs/mail/inc/header.inc.php
@@ -37,80 +37,80 @@ ul[id$="sortable-inactive"] li {cursor:move }
 	background: #66CD00;
 }
 table[data-sortable] {
-  border-collapse: collapse;
-  border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 table[data-sortable] th {
-  vertical-align: bottom;
-  font-weight: bold;
+  vertical-align: bottom;
+  font-weight: bold;
 }
 table[data-sortable] th, table[data-sortable] td {
-  text-align: left;
-  padding: 10px;
+  text-align: left;
+  padding: 10px;
 }
 table[data-sortable] th:not([data-sortable="false"]) {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
-  user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  -webkit-touch-callout: none;
-  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-touch-callout: none;
+  cursor: pointer;
 }
 table[data-sortable] th:after {
-  content: "";
-  visibility: hidden;
-  display: inline-block;
-  vertical-align: inherit;
-  height: 0;
-  width: 0;
-  border-width: 5px;
-  border-style: solid;
-  border-color: transparent;
-  margin-right: 1px;
-  margin-left: 10px;
-  float: right;
+  content: "";
+  visibility: hidden;
+  display: inline-block;
+  vertical-align: inherit;
+  height: 0;
+  width: 0;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent;
+  margin-right: 1px;
+  margin-left: 10px;
+  float: right;
 }
 table[data-sortable] th[data-sortable="false"]:after {
-  display: none;
+  display: none;
 }
 table[data-sortable] th[data-sorted="true"]:after {
-  visibility: visible;
+  visibility: visible;
 }
 table[data-sortable] th[data-sorted-direction="descending"]:after {
-  border-top-color: inherit;
-  margin-top: 8px;
+  border-top-color: inherit;
+  margin-top: 8px;
 }
 table[data-sortable] th[data-sorted-direction="ascending"]:after {
-  border-bottom-color: inherit;
-  margin-top: 3px;
+  border-bottom-color: inherit;
+  margin-top: 3px;
 }
 table[data-sortable].sortable-theme-bootstrap thead th {
-  border-bottom: 2px solid #e0e0e0;
+  border-bottom: 2px solid #e0e0e0;
 }
 table[data-sortable].sortable-theme-bootstrap th[data-sorted="true"] {
-  color: #3a87ad;
-  background: #d9edf7;
-  border-bottom-color: #bce8f1;
+  color: #3a87ad;
+  background: #d9edf7;
+  border-bottom-color: #bce8f1;
 }
 table[data-sortable].sortable-theme-bootstrap th[data-sorted="true"][data-sorted-direction="descending"]:after {
-  border-top-color: #3a87ad;
+  border-top-color: #3a87ad;
 }
 table[data-sortable].sortable-theme-bootstrap th[data-sorted="true"][data-sorted-direction="ascending"]:after {
-  border-bottom-color: #3a87ad;
+  border-bottom-color: #3a87ad;
 }
 table[data-sortable].sortable-theme-bootstrap.sortable-theme-bootstrap-striped tbody > tr:nth-child(odd) > td {
-  background-color: #f9f9f9;
+  background-color: #f9f9f9;
 }
 .btn {
-   text-transform: none;
+   text-transform: none;
 }
 #data td, #no-data td {
 	vertical-align: middle;
 }
 .sort-table:hover {
-  border-bottom-color: #00B7DC !important;
+  border-bottom-color: #00B7DC !important;
 }
 </style>
 <?php
@@ -139,7 +139,7 @@ endif;
 ?>
 </head>
 <body style="padding-top:70px">
-<nav class="navbar navbar-default navbar-fixed-top"  role="navigation">
+<nav class="navbar navbar-default navbar-fixed-top"  role="navigation">
 	<div class="container-fluid">
 		<div class="navbar-header">
 			<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">

--- a/webserver/htdocs/mail/inc/prerequisites.inc.php
+++ b/webserver/htdocs/mail/inc/prerequisites.inc.php
@@ -20,21 +20,39 @@ $opt = [
 ];
 $pdo = new PDO($dsn, $database_user, $database_pass, $opt);
 
-if (isset($_POST['lang'])) {
-	switch ($_POST['lang']) {
+$_SESSION['mailcow_locale'] = strtolower(trim($DEFAULT_LANG));
+setcookie('language', $DEFAULT_LANG);
+if (isset($_COOKIE['language'])) {
+	switch ($_COOKIE['language']) {
 		case "de":
 			$_SESSION['mailcow_locale'] = 'de';
+			setcookie('language', 'de');
 		break;
 		case "en":
 			$_SESSION['mailcow_locale'] = 'en';
+			setcookie('language', 'en');
 		break;
 		case "pt":
 			$_SESSION['mailcow_locale'] = 'pt';
+			setcookie('language', 'pt');
 		break;
 	}
 }
-if (!isset($_SESSION['mailcow_locale'])) {
-	$_SESSION['mailcow_locale'] = strtolower(trim($DEFAULT_LANG));
+if (isset($_GET['lang'])) {
+	switch ($_GET['lang']) {
+		case "de":
+			$_SESSION['mailcow_locale'] = 'de';
+			setcookie('language', 'de');
+		break;
+		case "en":
+			$_SESSION['mailcow_locale'] = 'en';
+			setcookie('language', 'en');
+		break;
+		case "pt":
+			$_SESSION['mailcow_locale'] = 'pt';
+			setcookie('language', 'pt');
+		break;
+	}
 }
 require_once 'lang/lang.en.php';
 include 'lang/lang.'.$_SESSION['mailcow_locale'].'.php';

--- a/webserver/htdocs/mail/index.php
+++ b/webserver/htdocs/mail/index.php
@@ -43,9 +43,9 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 									<span class="lang-sm lang-lbl" lang="<?=$_SESSION['mailcow_locale'];?>"></span> <span class="caret"></span>
 								</button>
 								<ul class="dropdown-menu">
-									<li <?=($_SESSION['mailcow_locale'] == 'de') ? 'class="active"' : ''?>><a href="#" onClick="setLang('de')"><span class="lang-xs lang-lbl-full" lang="de"></span></a></li>
-									<li <?=($_SESSION['mailcow_locale'] == 'en') ? 'class="active"' : ''?>><a href="#" onClick="setLang('en')"><span class="lang-xs lang-lbl-full" lang="en"></span></a></li>
-									<li <?=($_SESSION['mailcow_locale'] == 'pt') ? 'class="active"' : ''?>><a href="#" onClick="setLang('pt')"><span class="lang-xs lang-lbl-full" lang="pt"></span></a></li>
+									<li <?=($_SESSION['mailcow_locale'] == 'de') ? 'class="active"' : ''?>><a href="?<?= http_build_query(array_merge($_GET, array("lang" => "de"))) ?>"><span class="lang-xs lang-lbl-full" lang="de"></span></a></li>
+									<li <?=($_SESSION['mailcow_locale'] == 'en') ? 'class="active"' : ''?>><a href="?<?= http_build_query(array_merge($_GET, array("lang" => "en"))) ?>"><span class="lang-xs lang-lbl-full" lang="en"></span></a></li>
+									<li <?=($_SESSION['mailcow_locale'] == 'pt') ? 'class="active"' : ''?>><a href="?<?= http_build_query(array_merge($_GET, array("lang" => "pt"))) ?>"><span class="lang-xs lang-lbl-full" lang="pt"></span></a></li>
 								</ul>
 							</div>
 						</div>


### PR DESCRIPTION
## Fixes #617 
This fix makes switching to new language more convenient by utilizing GET query, instead of POST.

**This means:**
* Users can switch language by opening "https://[mail.example.com]/?lang=**en**", where **en** can be **pt** or **de**.
* Every language switching activity will be cached in the cookie for future use.
  * Logging out will not reset the language to default.
  * Language will not change in the cookie unless you explicitly switched language via mailcow web ui.
* Switching to another language while in a page with get query works well.