### PR TITLE
Terminate of Script After Redirect Directive

### DIFF
--- a/webserver/htdocs/mail/add.php
+++ b/webserver/htdocs/mail/add.php
@@ -3,6 +3,7 @@ require_once("inc/prerequisites.inc.php");
 $AuthUsers = array("admin", "domainadmin");
 if (!isset($_SESSION['mailcow_cc_role']) OR !in_array($_SESSION['mailcow_cc_role'], $AuthUsers)) {
 	header('Location: /');
+	exit();
 }
 require_once("inc/header.inc.php");
 ?>

--- a/webserver/htdocs/mail/admin.php
+++ b/webserver/htdocs/mail/admin.php
@@ -498,5 +498,6 @@ foreach($ssr_values_inactive as $ssr_value) {
 require_once("inc/footer.inc.php");
 } else {
 	header('Location: /');
+	exit();
 }
 ?>

--- a/webserver/htdocs/mail/delete.php
+++ b/webserver/htdocs/mail/delete.php
@@ -3,6 +3,7 @@ require_once("inc/prerequisites.inc.php");
 $AuthUsers = array("admin", "domainadmin");
 if (!isset($_SESSION['mailcow_cc_role']) OR !in_array($_SESSION['mailcow_cc_role'], $AuthUsers)) {
 	header('Location: /');
+	exit();
 }
 require_once("inc/header.inc.php");
 ?>

--- a/webserver/htdocs/mail/edit.php
+++ b/webserver/htdocs/mail/edit.php
@@ -3,6 +3,7 @@ require_once("inc/prerequisites.inc.php");
 $AuthUsers = array("admin", "domainadmin");
 if (!isset($_SESSION['mailcow_cc_role']) OR !in_array($_SESSION['mailcow_cc_role'], $AuthUsers)) {
 	header('Location: /');
+	exit();
 }
 require_once("inc/header.inc.php");
 ?>

--- a/webserver/htdocs/mail/index.php
+++ b/webserver/htdocs/mail/index.php
@@ -3,12 +3,15 @@ require_once("inc/prerequisites.inc.php");
 
 if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == "admin") {
 	header('Location: /admin.php');
+	exit();
 }
 elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == "domainadmin") {
 	header('Location: /mailbox.php');
+	exit();
 }
 elseif (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == "user") {
 	header('Location: /user.php');
+	exit();
 }
 require_once("inc/header.inc.php");
 $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];

--- a/webserver/htdocs/mail/mailbox.php
+++ b/webserver/htdocs/mail/mailbox.php
@@ -495,5 +495,6 @@ $_SESSION['return_to'] = $_SERVER['REQUEST_URI'];
 require_once("inc/footer.inc.php");
 } else {
 	header('Location: /');
+	exit();
 }
 ?>

--- a/webserver/htdocs/mail/user.php
+++ b/webserver/htdocs/mail/user.php
@@ -321,5 +321,6 @@ if (isset($_SESSION['mailcow_cc_role']) && $_SESSION['mailcow_cc_role'] == 'user
 require_once("inc/footer.inc.php");
 } else {
 	header('Location: /');
+	exit();
 }
 ?>


### PR DESCRIPTION
If PHP scripts are not exited after declaring a location header, execution will continue. This is for security and performance purposes.