### PR TITLE
Uses template to set anonymize headers

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -380,6 +380,7 @@ DEBIAN_FRONTEND=noninteractive ${APT} -y install dovecot-common dovecot-core dov
 			install -m 644 postfix/conf/master.cf /etc/postfix/master.cf
 			install -m 644 postfix/conf/main.cf /etc/postfix/main.cf
 			install -o www-data -g www-data -m 644 postfix/conf/mailcow_anonymize_headers.pcre /etc/postfix/mailcow_anonymize_headers.pcre
+            install -o www-data -g www-data -m 644 postfix/conf/mailcow_anonymize_headers.pcre /etc/postfix/mailcow_anonymize_headers.pcre.template
 			install -m 644 postfix/conf/postscreen_access.cidr /etc/postfix/postscreen_access.cidr
 			install -m 644 postfix/conf/smtp_dsn_filter.pcre /etc/postfix/smtp_dsn_filter.pcre
 			sed -i "s/sys_hostname.sys_domain/${sys_hostname}.${sys_domain}/g" /etc/postfix/main.cf

--- a/webserver/htdocs/mail/inc/functions.inc.php
+++ b/webserver/htdocs/mail/inc/functions.inc.php
@@ -205,13 +205,8 @@ function set_mailcow_config($s, $v = '') {
 			}
 			break;
 		case "anonymize":
-			$template = '/^\s*(Received: from)[^\n]*(.*)/ REPLACE $1 [127.0.0.1] (localhost [127.0.0.1])$2
-/^\s*User-Agent/        IGNORE
-/^\s*X-Enigmail/        IGNORE
-/^\s*X-Mailer/          IGNORE
-/^\s*X-Originating-IP/  IGNORE
-		';
 			if ($v == "on") {
+                $template = file_get_contents($GLOBAL["MC_ANON_HEADERS"].".template");
 				file_put_contents($GLOBALS["MC_ANON_HEADERS"], $template);
 			} else {
 				file_put_contents($GLOBALS["MC_ANON_HEADERS"], "");


### PR DESCRIPTION
The hardcoded template for the anonymizer headers in functions.inc.php
didnt match the default file in postfix/conf/. This fixes this problem by creating a template and loading
the contents of this file to write to the config file.