### PR TITLE
Update Main.cf headers Id to mail

### DIFF
--- a/postfix/conf/main.cf
+++ b/postfix/conf/main.cf
@@ -256,3 +256,6 @@ milter_default_action = accept
 
 # Hard-fail missing TLS when enabled for a user
 plaintext_reject_code = 550
+
+# Add headers Id to Outgoing Mail 
+always_add_missing_headers = yes 


### PR DESCRIPTION
Add always_add_missing_headers = yes  for create a headers Id in the outgoing mails 