### PR TITLE
LE: Restart Postfix and Dovecot

### DIFF
--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -332,6 +332,8 @@ DEBIAN_FRONTEND=noninteractive ${APT} -y install dovecot-common dovecot-core dov
 					ln -s /etc/ssl/mail/certs/${sys_hostname}.${sys_domain}/privkey.pem /etc/ssl/mail/mail.key
 				fi
 				service ${httpd_platform} restart
+				service dovecot restart
+				service postfix restart
 			fi
 			;;
 		mysql)


### PR DESCRIPTION
When successfully acquiring a Let's Encrypt certificate we leave the user with wrong certificates in Dovecot and Postfix.
Added both services in `ssl-le` to be restarted. A "cleaner" approach could be to restructure [install.sh](https://github.com/andryyy/mailcow/blob/master/install.sh) and move L138 - L141 in front of restarting all services.

Edit: Spelling.