### PR TITLE
Added support for Debian 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mailcow
 
 mailcow is a mail server suite based on Dovecot, Postfix and other open source software, that provides a modern web UI for user/server administration.
 
-mailcow supports **Debian 8 (Jessie), Ubuntu LTS 14.04 (Trusty Tahr) and Ubuntu LTS 16.04 (Xenial Xerus)**
+mailcow supports **Debian 8 (Jessie), Debian 9 (Stretch), Ubuntu LTS 14.04 (Trusty Tahr) and Ubuntu LTS 16.04 (Xenial Xerus)**
 
 [Everybody loves screenshots (v0.14)](http://imgur.com/a/lWX2V)
 

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -178,6 +178,7 @@ installtask() {
 		installpackages)
 			dist_codename=$(lsb_release -cs)
 			dist_id=$(lsb_release -is)
+			PHPMAILMIMEDECODE="php-mail-mimedecode"
 			if [[ ! -z $(apt-cache search --names-only '^php5-cli$') ]]; then
 				PHP="php5"
 				PHPV="5"
@@ -200,6 +201,18 @@ installtask() {
 					fi
 					OPENJDK="openjdk-7"
 					JETTY_NAME="jetty8"
+				elif [[ ${dist_codename} == "stretch" ]]; then
+					#Debian 9 will not start Postfix or Dovecot when SSLv2 parameter is used. There is no support for php-mail-mimedecode
+					sed -i 's/!SSLv2, //g' ./postfix/conf/main.cf
+					sed -i 's/!SSLv2//g' ./dovecot/conf/dovecot.conf
+					PHPMAILMIMEDECODE=""
+					if [[ ${httpd_platform} == "apache2" ]]; then
+						WEBSERVER_BACKEND="apache2 apache2-utils libapache2-mod-${PHP}"
+					else
+						WEBSERVER_BACKEND="nginx-extras ${PHP}-fpm"
+					fi
+					OPENJDK="openjdk-8"
+					JETTY_NAME="jetty9"
 				else
 					echo "$(redb [ERR]) - Your Debian distribution is currently not supported"
 					exit 1
@@ -242,13 +255,17 @@ installtask() {
 					DATABASE_BACKEND="mariadb-client mariadb-server"
 				else
 					DATABASE_BACKEND="mysql-client mysql-server"
+					# In Debian 9 the mysql-client package was renamed to default-mysql-client
+					if [[ ${dist_codename} == "stretch" ]]; then
+						DATABASE_BACKEND="default-mysql-client default-mysql-server"
+					fi
 				fi
 			else
 				DATABASE_BACKEND=""
 			fi
 			[[ -z ${APT} ]] && APT="apt-get --force-yes"
 DEBIAN_FRONTEND=noninteractive ${APT} -y install dnsutils sudo zip bzip2 unzip unrar-free curl rrdtool mailgraph fcgiwrap spawn-fcgi python-setuptools libmail-spf-perl libmail-dkim-perl file bsd-mailx \
-openssl php-auth-sasl php-http-request php-mail php-mail-mime php-mail-mimedecode php-net-dime php-net-smtp \
+openssl php-auth-sasl php-http-request php-mail php-mail-mime ${PHPMAILMIMEDECODE} php-net-dime php-net-smtp \
 php-net-socket php-net-url php-pear php-soap ${PHP} ${PHP}-cli ${PHP}-common ${PHP}-curl ${PHP}-gd ${PHP}-imap \
 ${PHP}-intl ${PHP}-xsl ${PHP}-mcrypt ${PHP}-mysql libawl-php ${PHP}-xmlrpc ${DATABASE_BACKEND} ${WEBSERVER_BACKEND} mailutils pyzor razor \
 postfix postfix-mysql postfix-pcre postgrey pflogsumm spamassassin spamc sa-compile libdbd-mysql-perl opendkim opendkim-tools clamav-daemon \


### PR DESCRIPTION
Debian 9 will be released within the next month. To prepare mailcow for the comming release I have added support for Debian 9.
There are some neccessary changes:

Added variable for php-mail-mimedecode (There is no support for it in stretch)
Added elif to distro chain

If Debian 9 is decected:
- Remove parameter SSLv2 from main.conf and dovecot.conf (no support for SSLv2 in stretch)
- Change mysql-server mysql-client to default-mysql-server default-mysql-client (Renamed in stretch)
- Set variable PHPMAILMIMEDECODE=""
- Set variable OPENJDK="openjdk-8"
- Set variable JETTY_NAME="jetty9"

The Setup was tested on Debian 9 with apache2 and mysl.

Please review the changes and merge it into master.
Best regards,
addictedtoberlin